### PR TITLE
Updates towards a cleaner Open Source release

### DIFF
--- a/lib/phoenix_tcp/ranch_handler.ex
+++ b/lib/phoenix_tcp/ranch_handler.ex
@@ -11,7 +11,7 @@ defmodule PhoenixTCP.RanchHandler do
       {transport, {module, config}} <- socket.__transports__,
       # allow handlers to be configured at the transport level
       transport == :tcp,
-      handler = config[:tcp] || default_for(module),
+      handler = config[:tcp_server] || default_for(module),
       into: %{},
       do: {Path.join(path, Atom.to_string(transport)),
            # handler being the tcp protocol implementing module

--- a/lib/phoenix_tcp/ranch_server.ex
+++ b/lib/phoenix_tcp/ranch_server.ex
@@ -1,7 +1,6 @@
 defmodule PhoenixTCP.RanchServer do
 	use GenServer
   require Logger
-  require IEx
 
   @behavious :ranch_protocol
 
@@ -16,58 +15,65 @@ defmodule PhoenixTCP.RanchServer do
     state = %{
       tcp_transport: tcp_transport,
       tcp_socket: tcp_socket,
-      handlers: Keyword.fetch!(opts, :handlers)
+      handlers: Keyword.fetch!(opts, :handlers),
+      serializer: opts[:serializer] || Poison
     }
     :gen_server.enter_loop(__MODULE__, [], state)
   end
 
-  def handle_info({:tcp, tcp_socket, data}, %{handlers: handlers, tcp_transport: tcp_transport} = state) do
-    %{"path" => path, "params" => params} =
-      String.rstrip(data)
-      |> Poison.decode!()
-    case Map.get(handlers, path) do
-      # handler is the server which handles the tcp messages
-      # currently there is only one server, 
-      # module is the transport module
-      # opts = {endpoint, socket, transport}
-      # endpoint being the endpoint defined in the phx app
-      # socket being the socket defined in the phx app
-      # transport being the atom defining the transport
-      {handler, module, opts} ->
-        case module.init(params, opts) do
-          {:ok, {module, {opts, timeout}}} ->
-            state = %{
-              tcp_transport: tcp_transport,
-              tcp_socket: tcp_socket,
-              handler: handler,
-              transport_module: module,
-              transport_config: opts,
-              timeout: timeout
-            }
-            :ok = tcp_transport.setopts(tcp_socket, [active: :once])
-            connected_msg = Poison.encode!(%{"payload" => %{"status" => "ok", "response" => "connected"}})
-            tcp_transport.send(tcp_socket, connected_msg)
-            {:noreply, state, timeout}
-          {:error, error_msg} ->
-            status_error_msg = Poison.encode!(%{"payload" => %{"status" => "error", "response" => error_msg}})
-            tcp_transport.send(tcp_socket, status_error_msg)
+  def handle_info({:tcp, tcp_socket, data}, %{handlers: handlers, tcp_transport: tcp_transport, serializer: serializer} = state) do
+    case serializer.decode(data) do
+      {:ok, %{"path" => path, "params" => params}} ->
+        case Map.get(handlers, path) do
+          # handler is the server which handles the tcp messages
+          # currently there is only one server,
+          # module is the transport module
+          # opts = {endpoint, socket, transport}
+          # endpoint being the endpoint defined in the phx app
+          # socket being the socket defined in the phx app
+          # transport being the atom defining the transport
+          {handler, module, opts} ->
+            case module.init(params, opts) do
+              {:ok, {module, {opts, timeout}}} ->
+                state = %{
+                  tcp_transport: tcp_transport,
+                  tcp_socket: tcp_socket,
+                  handler: handler,
+                  transport_module: module,
+                  transport_config: opts,
+                  timeout: timeout
+                }
+                :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+                connected_msg = serializer.encode!(connected_json)
+                tcp_transport.send(tcp_socket, connected_msg)
+                {:noreply, state, timeout}
+              {:error, error_msg} ->
+                status_error_msg = serializer.encode!(%{"payload" => %{"status" => "error", "response" => error_msg}})
+                tcp_transport.send(tcp_socket, status_error_msg)
+                :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+                {:noreply, state}
+            end
+          nil ->
+            error_msg = serializer.encode!(%{"payload" => %{"status" => "error", "response" => "no path matches"}})
+            tcp_transport.send(tcp_socket, error_msg)
             :ok = tcp_transport.setopts(tcp_socket, [active: :once])
             {:noreply, state}
         end
-      nil ->
-        error_msg = Poison.encode!(%{"payload" => %{"status" => "error", "response" => "no path matches"}})
-        tcp_transport.send(tcp_socket, "no path matches")
+      {:error, _error} ->
+        error_msg = serializer.encode!(%{"payload" => %{"status" => "error", "response" => "Unable to decode data with #{serializer}"}})
+        tcp_transport.send(tcp_socket, error_msg)
+        Logger.warn "Unable to decode data in #{__MODULE__}'s handle_info() using #{serializer}"
         :ok = tcp_transport.setopts(tcp_socket, [active: :once])
         {:noreply, state}
     end
   end
 
-  def handle_info({:tcp, _tcp_socket, payload}, 
+  def handle_info({:tcp, _tcp_socket, payload},
     %{transport_module: module, transport_config: config} = state) do
     handle_reply state, module.tcp_handle(payload, config)
   end
 
-  def handle_info({:tcp_closed, _tcp_socket}, 
+  def handle_info({:tcp_closed, _tcp_socket},
     %{transport_module: module, transport_config: config} = state) do
     module.tcp_close(config)
     {:stop, :shutdown, state}
@@ -104,12 +110,20 @@ defmodule PhoenixTCP.RanchServer do
     {:noreply, new_state, timeout}
   end
 
-  defp handle_reply(%{timeout: timeout, tcp_transport: transport, tcp_socket: socket} = state, 
+  defp handle_reply(%{timeout: timeout, tcp_transport: transport, tcp_socket: socket} = state,
       {:reply, {_encoding, encoded_payload}, new_config}) do
     transport.send(socket, encoded_payload)
     :ok = transport.setopts(socket, [active: :once])
     new_state = Map.put(state, :transport_config, new_config)
     {:noreply, new_state, timeout}
+  end
+
+  defp connected_json do
+    %{"payload" => %{"status" => "ok",
+      "response" => "connected"},
+    "topic" => "",
+    "event" => "",
+    "ref" => nil}
   end
 
 end

--- a/lib/phoenix_tcp/ranch_server.ex
+++ b/lib/phoenix_tcp/ranch_server.ex
@@ -2,7 +2,7 @@ defmodule PhoenixTCP.RanchServer do
 	use GenServer
   require Logger
 
-  @behavious :ranch_protocol
+  @behaviour :ranch_protocol
 
   def start_link(ref, tcp_socket, tcp_transport, opts \\ []) do
     :proc_lib.start_link(__MODULE__, :init, [ref, tcp_socket, tcp_transport, opts])

--- a/lib/phoenix_tcp/ranch_server.ex
+++ b/lib/phoenix_tcp/ranch_server.ex
@@ -105,8 +105,10 @@ defmodule PhoenixTCP.RanchServer do
     {:stop, :shutdown, new_state}
   end
 
-  defp handle_reply(%{timeout: timeout} = state, {:ok, new_config}) do
+  defp handle_reply(%{timeout: timeout, tcp_transport: transport,
+    tcp_socket: socket} = state, {:ok, new_config}) do
     new_state = Map.put(state, :transport_config, new_config)
+    :ok = transport.setopts(socket, [active: :once])
     {:noreply, new_state, timeout}
   end
 


### PR DESCRIPTION
This PR updates the `RanchServer` and `RanchHandler` in order to remove the HubProtocol dependency which has now been moved into a separate repo. 

It also includes minor fixes to the RanchServer for tests to pass and to properly handle a particular `:timeout` message